### PR TITLE
顔よりマクドナルドのコーヒーが優先される問題の修正

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,25 +39,16 @@ def detect_face(image_data, params):
     if not faces:
         return {"error": "指定されたサイズ以上の顔が検出されませんでした。", "status": 404}
 
-    # 信頼度順に顔をソート
-    faces.sort(key=lambda f: f["score"], reverse=True)
+    # 信頼度が最も高い顔を選択
+    best_face = max(faces, key=lambda f: f["score"])
 
-    # 各顔を切り抜き
-    face_images = []
-    for face in faces:
-        x, y, w, h = face["bbox"]
-        face_image = image[y:y+h, x:x+w]
-        face_images.append(face_image)
-
-    # 横並びに結合
-    try:
-        combined_image = cv2.hconcat(face_images)
-    except cv2.error as e:
-        return {"error": f"顔の結合に失敗しました: {str(e)}", "status": 500}
+    # 顔部分を切り抜き
+    x, y, w, h = best_face["bbox"]
+    face_image = image[y:y+h, x:x+w]
 
     # バイナリデータを返却
-    _, buffer = cv2.imencode('.jpg', combined_image)
-    return buffer, combined_image.shape[:2]  # 高さと幅を返却
+    _, buffer = cv2.imencode('.jpg', face_image)
+    return buffer, (w, h)
 
 @app.route('/detect', methods=['POST'])
 def detect():

--- a/app.py
+++ b/app.py
@@ -141,6 +141,7 @@ def detect_form():
             // 各フォーム要素に値をセット
             const formElements = document.querySelectorAll("form [name]");
             formElements.forEach((el) => {
+              if (el.type === "file") return; // <input type="file"> はスキップ
               if (cookies[el.name]) {
                 el.value = cookies[el.name];
               }

--- a/app.py
+++ b/app.py
@@ -128,10 +128,12 @@ def detect_form():
             const formData = new FormData(form);
 
             try {
+              const startTime = performance.now(); // リクエスト開始時間
               const response = await fetch(form.action, {
                 method: form.method,
                 body: formData
               });
+              const endTime = performance.now(); // レスポンス受信時間
 
               const resultDiv = document.getElementById('result');
               if (response.ok) {
@@ -139,13 +141,27 @@ def detect_form():
                 const imgUrl = URL.createObjectURL(blob);
                 const width = response.headers.get('X-Image-Width');
                 const height = response.headers.get('X-Image-Height');
-                resultDiv.innerHTML = `<img class="img-fluid" src="${imgUrl}" alt="Detected Face"><p>Width: ${width}px, Height: ${height}px</p>`;
+                const elapsedTime = Math.round(endTime - startTime); // 経過時間 (ミリ秒)
+                
+                resultDiv.innerHTML = `
+                  <img class="img-fluid" src="${imgUrl}" alt="Detected Face">
+                  <p>Width: ${width}px, Height: ${height}px</p>
+                  <p>Elapsed Time: ${elapsedTime} ms</p>
+                `;
               } else {
                 const error = await response.json();
-                resultDiv.innerHTML = `<div class="alert alert-danger" role="alert">エラー (${response.status}): ${error.error}</div>`;
+                resultDiv.innerHTML = `
+                  <div class="alert alert-danger" role="alert">
+                    エラー (${response.status}): ${error.error}
+                  </div>
+                `;
               }
             } catch (err) {
-              document.getElementById('result').innerHTML = `<div class="alert alert-danger" role="alert">エラー: ${err.message}</div>`;
+              document.getElementById('result').innerHTML = `
+                <div class="alert alert-danger" role="alert">
+                  エラー: ${err.message}
+                </div>
+              `;
             }
           }
         </script>

--- a/app.py
+++ b/app.py
@@ -121,11 +121,44 @@ def detect_form():
         <title>Face Detector</title>
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
         <script>
+          // Cookieにフォームの値を保存
+          function saveFormToCookie(formData) {
+            const expires = new Date();
+            expires.setFullYear(expires.getFullYear() + 1); // 1年有効
+            formData.forEach((value, key) => {
+              document.cookie = `${key}=${encodeURIComponent(value)}; expires=${expires.toUTCString()}; path=/`;
+            });
+          }
+
+          // Cookieからフォームの値を取得
+          function loadFormFromCookie() {
+            const cookies = document.cookie.split(";").reduce((acc, cookie) => {
+              const [key, value] = cookie.trim().split("=");
+              acc[decodeURIComponent(key)] = decodeURIComponent(value);
+              return acc;
+            }, {});
+
+            // 各フォーム要素に値をセット
+            const formElements = document.querySelectorAll("form [name]");
+            formElements.forEach((el) => {
+              if (cookies[el.name]) {
+                el.value = cookies[el.name];
+              }
+            });
+          }
+
+          document.addEventListener("DOMContentLoaded", () => {
+            loadFormFromCookie(); // ページ読み込み時にCookieから値を反映
+          });
+
           async function handleSubmit(event) {
             event.preventDefault();
 
             const form = event.target;
             const formData = new FormData(form);
+
+            // フォームデータをCookieに保存
+            saveFormToCookie(formData);
 
             try {
               const startTime = performance.now(); // リクエスト開始時間


### PR DESCRIPTION
顔のサイズじゃなくて信用度が最も高いものを採用するように変更

ただ、それだけだとまだコーヒーが検出されるので、指定したxyで切り取った上で検出できる仕様を追加

Ringのカメラは1080x1080pxなので、200pxずつカットして検証すると私の顔が検出されるようになったのでこれで試してみる

![2025-01-12-13-13-12-069_comp](https://github.com/user-attachments/assets/b65d30db-69cd-4fc7-8d97-77461354a764)
